### PR TITLE
Add Laravel 13 and PHP 8.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,20 +21,22 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.1, 8.2, 8.3, 8.4]
-                laravel: [10.*, 11.*, 12.*]
+                php: [8.1, 8.2, 8.3, 8.4, 8.5]
+                laravel: [10.*, 11.*, 12.*, 13.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 exclude:
                   - php: 8.1
                     laravel: 11.*
                   - laravel: 12.*
                     php: 8.1
+                  - laravel: 13.*
+                    php: 8.1
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v1
+              uses: actions/checkout@v4
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/database": "10.*|11.*|12.*",
-        "illuminate/support": "10.*|11.*|12.*"
+        "illuminate/database": "10.*|11.*|12.*|13.*",
+        "illuminate/support": "10.*|11.*|12.*|13.*"
     },
     "require-dev": {
-        "laravel/laravel": "10.*|11.*|12.*",
-        "makeabledk/laravel-factory-enhanced": "^6.0",
+        "laravel/laravel": "10.*|11.*|12.*|13.*",
+        "makeabledk/laravel-factory-enhanced": "^6.0|^7.0",
         "fakerphp/faker": "^1.19",
         "mockery/mockery": "^1.5",
         "phpunit/phpunit": "^10.5.17|^11.0"


### PR DESCRIPTION
## Summary
- add Laravel 13 support to package constraints
- allow newer `makeabledk/laravel-factory-enhanced` versions in dev dependencies
- add Laravel 13 and PHP 8.5 to the CI matrix
- exclude Laravel 13 on PHP 8.1, matching the existing low-PHP exclusions
- update GitHub Actions checkout to v4 while touching the workflow

## Testing
- composer update
- vendor/bin/phpunit

## Notes
- local dependency resolution succeeds against Laravel 13 and picks `makeabledk/laravel-factory-enhanced v6.2.0`
- local test execution in this environment fails on MySQL auth because the repository test suite expects the CI MySQL service configuration; GitHub Actions should be the authoritative run for DB-backed tests
